### PR TITLE
Added delete implementation in presentation layer

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.application'
+    id 'kotlin-kapt'
     id 'org.jetbrains.kotlin.android'
     id 'androidx.navigation.safeargs.kotlin'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Material3.DayNight.NoActionBar"
+        android:theme="@style/AppTheme"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/antgut/app/snackbar/snackbar.kt
+++ b/app/src/main/java/com/antgut/app/snackbar/snackbar.kt
@@ -2,10 +2,18 @@ package com.antgut.app.snackbar
 
 
 import android.os.Bundle
+import android.view.View
 import androidx.fragment.app.Fragment
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 
 fun Fragment.showSnackbar(text: String) {
     Snackbar.make(requireView(),text,BaseTransientBottomBar.LENGTH_SHORT).show()
+}
+fun View.showSnackbar(text:String) {
+    Snackbar.make(
+        this,
+        text,
+        BaseTransientBottomBar.LENGTH_SHORT
+    ).show()
 }

--- a/app/src/main/java/com/antgut/app/snackbar/snackbar.kt
+++ b/app/src/main/java/com/antgut/app/snackbar/snackbar.kt
@@ -1,0 +1,11 @@
+package com.antgut.app.snackbar
+
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import com.google.android.material.snackbar.BaseTransientBottomBar
+import com.google.android.material.snackbar.Snackbar
+
+fun Fragment.showSnackbar(text: String) {
+    Snackbar.make(requireView(),text,BaseTransientBottomBar.LENGTH_SHORT).show()
+}

--- a/app/src/main/java/com/antgut/rss_app/management/presentation/FormFragment.kt
+++ b/app/src/main/java/com/antgut/rss_app/management/presentation/FormFragment.kt
@@ -7,11 +7,10 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.navigation.fragment.findNavController
 import com.antgut.app.serializer.GsonSerializer
+import com.antgut.app.snackbar.showSnackbar
 import com.antgut.rss_app.R
 import com.antgut.rss_app.databinding.FragmentUserFormBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import com.google.android.material.snackbar.BaseTransientBottomBar
-import com.google.android.material.snackbar.Snackbar
 
 class FormFragment : BottomSheetDialogFragment() {
 
@@ -43,20 +42,11 @@ class FormFragment : BottomSheetDialogFragment() {
                     inputName.text.toString()
                 )
                 findNavController().navigateUp()
-                showBar()
+                showSnackbar(getString(R.string.snack_bar_save_text))
             }
             binding?.cancelButton?.setOnClickListener {
                 findNavController().navigateUp()
             }
         }
     }
-
-    fun showBar() {
-        Snackbar.make(
-            (requireActivity()).findViewById<ViewGroup>(R.id.main_view),
-            "Guardado",
-            BaseTransientBottomBar.LENGTH_SHORT
-        ).show()
-    }
-
 }

--- a/app/src/main/java/com/antgut/rss_app/management/presentation/FormFragment.kt
+++ b/app/src/main/java/com/antgut/rss_app/management/presentation/FormFragment.kt
@@ -42,7 +42,7 @@ class FormFragment : BottomSheetDialogFragment() {
                     inputName.text.toString()
                 )
                 findNavController().navigateUp()
-                showSnackbar(getString(R.string.snack_bar_save_text))
+                (requireActivity()).findViewById<ViewGroup>(R.id.main_view).showSnackbar(getString(R.string.snack_bar_save_text))
             }
             binding?.cancelButton?.setOnClickListener {
                 findNavController().navigateUp()

--- a/app/src/main/java/com/antgut/rss_app/management/presentation/ManagerFactory.kt
+++ b/app/src/main/java/com/antgut/rss_app/management/presentation/ManagerFactory.kt
@@ -4,12 +4,20 @@ import android.content.SharedPreferences
 import com.antgut.app.serializer.KSerializer
 import com.antgut.rss_app.management.data.RssDataRepository
 import com.antgut.rss_app.management.data.local.xml.XmlDataSource
+import com.antgut.rss_app.management.domain.DeleteRssUseCase
 import com.antgut.rss_app.management.domain.GetUserUseCase
 
 class ManagerFactory {
     fun getRss(serializer: KSerializer,sharedPreferences: SharedPreferences, ): ManagerViewModel {
         return ManagerViewModel(
             GetUserUseCase(
+                RssDataRepository(
+                    XmlDataSource(
+                        sharedPreferences, serializer
+                    )
+                )
+            ),
+            DeleteRssUseCase(
                 RssDataRepository(
                     XmlDataSource(
                         sharedPreferences, serializer

--- a/app/src/main/java/com/antgut/rss_app/management/presentation/ManagerFragment.kt
+++ b/app/src/main/java/com/antgut/rss_app/management/presentation/ManagerFragment.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.antgut.app.serializer.GsonSerializer
+import com.antgut.app.snackbar.showSnackbar
 import com.antgut.rss_app.R
 import com.antgut.rss_app.databinding.FragmentManagerBinding
 import com.antgut.rss_app.management.presentation.adapter.ManagerAdapter
@@ -71,6 +72,9 @@ class ManagerFragment : Fragment() {
                 false
             )
             skeleton = feedListRecyclerView.applySkeleton(R.layout.fragment_feed)
+            rssAdapter.setOnClick{viewModel?.deleteRss(it)
+                showSnackbar(getString(R.string.snack_bar_delete_text))
+            }
         }
     }
 

--- a/app/src/main/java/com/antgut/rss_app/management/presentation/ManagerViewModel.kt
+++ b/app/src/main/java/com/antgut/rss_app/management/presentation/ManagerViewModel.kt
@@ -3,12 +3,13 @@ package com.antgut.rss_app.management.presentation
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.antgut.rss_app.management.domain.DeleteRssUseCase
 import com.antgut.rss_app.management.domain.GetUserUseCase
 import com.antgut.rss_app.management.domain.ManagementModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class ManagerViewModel(private val getUserRssUseCase: GetUserUseCase) : ViewModel() {
+class ManagerViewModel(private val getUserRssUseCase: GetUserUseCase, private val deleteRssUseCase: DeleteRssUseCase) : ViewModel() {
 
     val managerPublisher: MutableLiveData<RssManagerFeedUiState> by lazy {
         MutableLiveData<RssManagerFeedUiState>()
@@ -25,6 +26,11 @@ class ManagerViewModel(private val getUserRssUseCase: GetUserUseCase) : ViewMode
                     rssFeed = rssFeed
                 )
             )
+        }
+    }
+    fun deleteRss(url:String){
+        viewModelScope.launch (Dispatchers.IO){
+            deleteRssUseCase.execute(url)
         }
     }
 

--- a/app/src/main/java/com/antgut/rss_app/management/presentation/adapter/ManagerAdapter.kt
+++ b/app/src/main/java/com/antgut/rss_app/management/presentation/adapter/ManagerAdapter.kt
@@ -15,6 +15,11 @@ class ManagerAdapter : RecyclerView.Adapter<ManagerViewHolder>(){
         setOfData.addAll(rssvalue)
         notifyDataSetChanged()
     }
+    private var clickItem: ((String) -> Unit)? =null
+
+    fun setOnClick(clickItem :(String) -> Unit){
+        this.clickItem = clickItem
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ManagerViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.fragment_user_item, parent, false)
@@ -22,7 +27,7 @@ class ManagerAdapter : RecyclerView.Adapter<ManagerViewHolder>(){
     }
 
     override fun onBindViewHolder(holder: ManagerViewHolder, position: Int) {
-        holder.bind(setOfData[position])
+        holder.bind(setOfData[position], clickItem)
     }
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/com/antgut/rss_app/management/presentation/adapter/ManagerViewHolder.kt
+++ b/app/src/main/java/com/antgut/rss_app/management/presentation/adapter/ManagerViewHolder.kt
@@ -6,10 +6,12 @@ import com.antgut.rss_app.databinding.FragmentUserItemBinding
 import com.antgut.rss_app.management.domain.ManagementModel
 
 class ManagerViewHolder (val view: View): RecyclerView.ViewHolder(view){
-    fun bind(rssvalue:ManagementModel){
+    fun bind(rssvalue: ManagementModel, clickItem: ((String) -> Unit)?){
         val binding = FragmentUserItemBinding.bind(view)
         binding.nombreRss.text = rssvalue.name
         binding.urlRss.text = rssvalue.url
+        binding.deleteItemIcon.setOnClickListener {
+            clickItem?.invoke(rssvalue.url)
+        }
     }
-
 }

--- a/app/src/main/res/layout/fragment_manager.xml
+++ b/app/src/main/res/layout/fragment_manager.xml
@@ -7,6 +7,7 @@
     android:layout_height="wrap_content">
 
     <androidx.appcompat.widget.Toolbar
+        style="@style/AppTheme"
         android:id="@+id/rss_manager_toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"

--- a/app/src/main/res/layout/fragment_user_item.xml
+++ b/app/src/main/res/layout/fragment_user_item.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_margin="@dimen/margin_item">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_margin="@dimen/margin_item"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content">
 
         <ImageView
             android:id="@+id/rss_icon"
@@ -40,14 +38,15 @@
             app:layout_constraintStart_toStartOf="@id/nombre_rss"
             tools:text="https://www.marca.com" />
 
-        <ImageView
+        <ImageButton
             android:id="@+id/delete_item_icon"
             android:layout_width="@dimen/delete_icon_size"
             android:layout_height="@dimen/delete_icon_size"
             android:src="@drawable/delete"
+            android:background="@android:color/transparent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.cardview.widget.CardView>
+

--- a/app/src/main/res/values-night/strings.xml
+++ b/app/src/main/res/values-night/strings.xml
@@ -15,4 +15,6 @@
     <string name="manager_textview_text">Manager</string>
     <string name="feed_textview_text">Feed</string>
     <string name="profile_textview_text">Profile</string>
+    <string name="snack_bar_save_text">Rss added</string>
+    <string name="snack_bar_delete_text">Rss deleted</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,6 @@
     <string name="manager_textview_text">Manager</string>
     <string name="feed_textview_text">Feed</string>
     <string name="profile_textview_text">Profile</string>
+    <string name="snack_bar_save_text">Rss added</string>
+    <string name="snack_bar_delete_text">Rss deleted</string>
 </resources>


### PR DESCRIPTION
## Description de la tarea
En esta rama he implemlementado la funcionalidad del borrado de rss
## ¿Cómo se ha implementado?
Primero he añadido la funcion del caso de uso de delete, despues he implementado todo lo que hicimos en el repositorio anteriormente a una funcion. Tambien he creado dos extensiones para el snackbar, una llamando al fragment por que no queria tener que buscar la vista por que es bastante codigo que tenia que usar dos veces al añadir y al borrar, pero no he podido usarlo mas que al borrar por que al hacer el navigate up cambia de fragmento y no me muestra el mensaje de añadido, asique he tenido que usar la otra extension de la vista y buscarla para el caso de añadir.
## Disclaimer
Es muy probable que quite el skeleton por que no le veo utilidad y no me gusta como queda
## Keywords
Presentation, ViewModel, Delete, ItemClick
## Video
[device-2022-12-12-131230.webm](https://user-images.githubusercontent.com/53609303/207042447-822af107-1db2-496c-87f8-46a29b2f174c.webm)